### PR TITLE
wave update and lives

### DIFF
--- a/Assets/Scenes/Easy.unity
+++ b/Assets/Scenes/Easy.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.18028352, g: 0.22571376, b: 0.30692244, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028292, g: 0.22571306, b: 0.30692118, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2384,10 +2384,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemySpawner: {fileID: 217600225}
-  timeBetweenWaves: 5
-  timeBetweenSpawns: 3
+  timeBetweenWaves: 10
+  timeBetweenSpawns: 1
   enemiesPerWave: 5
-  totalWaves: 3
+  totalWaves: 15
   waveUINum: {fileID: 103354851}
 --- !u!114 &1803163891
 MonoBehaviour:

--- a/Assets/scripts/Enemy/WaveSpawner.cs
+++ b/Assets/scripts/Enemy/WaveSpawner.cs
@@ -39,6 +39,7 @@ public class WaveSpawner : MonoBehaviour
         // If we have reached the total wave limit, stop spawning
         if (waveNumber >= totalWaves)
         {
+            Debug.Log("Done spawning");
             return;
         }
 

--- a/Assets/scripts/Enemy/WaveSpawner.cs
+++ b/Assets/scripts/Enemy/WaveSpawner.cs
@@ -9,9 +9,9 @@ public class WaveSpawner : MonoBehaviour
     public EnemySpawner enemySpawner; // Reference to EnemySpawner component
 
     public float timeBetweenWaves = 10f;     // 10-second delay between waves
-    public float timeBetweenSpawns = 3f;     // 3-second delay between each enemy spawn
+    public float timeBetweenSpawns = 1f;     // 3-second delay between each enemy spawn
     public int enemiesPerWave = 5;           // 5 enemies per wave
-    public int totalWaves = 3;               // Total number of waves
+    public int totalWaves = 15;               // Total number of waves
 
     /// <summary>
     /// These numbers above will eventually be changed into global variables that have numbers linked thoughout the gamemaster :D
@@ -52,6 +52,9 @@ public class WaveSpawner : MonoBehaviour
                     enemySpawner.SpawnEnemies();
                     enemiesSpawnedInWave++;
                     spawnCountDown = timeBetweenSpawns;
+                    //add new spawn enemy line here
+                    //will need to add if loop here if you want different spawn timings to normal enemies
+                    //i will do it, just let me (swenyee) know once new enemy type spawn has been created
                 }
                 spawnCountDown -= Time.deltaTime;
             }
@@ -61,6 +64,7 @@ public class WaveSpawner : MonoBehaviour
                 waveNumber++;
                 enemiesSpawnedInWave = 0;
                 waveCountDown = timeBetweenWaves;
+                enemiesPerWave = enemiesPerWave + 5;
             }
         }
         else

--- a/Assets/scripts/showEndUI.cs
+++ b/Assets/scripts/showEndUI.cs
@@ -3,13 +3,26 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class showEndUI : MonoBehaviour
+
 {
+
+    private int counter = 20;
 
     public GameObject gameObjectUI;
 
     public void NeededMethod() //sets inactive object to become active
     {
-        gameObjectUI.SetActive(true);
+
+        if (counter == 0)
+        {
+            gameObjectUI.SetActive(true);
+        }
+        else
+        {
+            counter--;
+        }
+
+        Debug.Log("This is how many lives you have" + counter);
         
     }
 }

--- a/Assets/scripts/showWinUI.cs
+++ b/Assets/scripts/showWinUI.cs
@@ -16,7 +16,7 @@ public class showWinUI : MonoBehaviour
     // Update is called once per frame
     void Update() //once 15 enemies have been defeated object will be set to active
     {
-        if (counter == 15)
+        if (counter == 600)
             gameObjectUI.SetActive(true);
     }
 


### PR DESCRIPTION
Updated waves system to allow up to 15 waves. Enemies increase in counts of 5 per wave as of now until new enemy types are developed. Added lives so 20 hits/enemies can run towards the final gate before "GAME OVER"