### PR TITLE
Keyboard mapping and targeting logic update

### DIFF
--- a/Assets/Imported/Alek Games/Placer 3/Light/User Data/Placer Deafults/Placer Deafults.asset
+++ b/Assets/Imported/Alek Games/Placer 3/Light/User Data/Placer Deafults/Placer Deafults.asset
@@ -317,5 +317,5 @@ MonoBehaviour:
       palette: {fileID: 11400000, guid: 99c7de03c7fa1ef4cae4b6cdfb47d8a8, type: 2}
       specificIndex: -1
   showWelcomeScreen: 0
-  projectOpened: 0
+  projectOpened: 1
   applicationClosesSinceAdValue: 2

--- a/Assets/playerInputs.cs
+++ b/Assets/playerInputs.cs
@@ -175,7 +175,7 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
                 {
                     ""name"": """",
                     ""id"": ""47d6e586-d32d-4a4a-9d04-6338849a26ad"",
-                    ""path"": ""<Mouse>/rightButton"",
+                    ""path"": ""<Mouse>/middleButton"",
                     ""interactions"": ""Press"",
                     ""processors"": """",
                     ""groups"": """",

--- a/Assets/playerInputs.cs
+++ b/Assets/playerInputs.cs
@@ -165,7 +165,18 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
                     ""name"": """",
                     ""id"": ""b19cdc51-52b4-4012-9de1-b597b8515c08"",
                     ""path"": ""<Keyboard>/#(C)"",
-                    ""interactions"": """",
+                    ""interactions"": ""Press"",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""CancelPlacement"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""47d6e586-d32d-4a4a-9d04-6338849a26ad"",
+                    ""path"": ""<Mouse>/rightButton"",
+                    ""interactions"": ""Press"",
                     ""processors"": """",
                     ""groups"": """",
                     ""action"": ""CancelPlacement"",
@@ -184,6 +195,74 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
                     ""isPartOfComposite"": false
                 }
             ]
+        },
+        {
+            ""name"": ""TowerSelection"",
+            ""id"": ""247614b0-e918-4fbd-bb5a-0b68b48bbcf7"",
+            ""actions"": [
+                {
+                    ""name"": ""SelectTower1"",
+                    ""type"": ""Button"",
+                    ""id"": ""bca5ff68-2b58-4914-8f29-c20929386a3f"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""SelectTower2"",
+                    ""type"": ""Button"",
+                    ""id"": ""8643e968-87f8-4240-b352-3334b84fbd17"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""SelectTower3"",
+                    ""type"": ""Button"",
+                    ""id"": ""e9a968f5-6ff3-40a7-b405-bdee9475be3a"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                }
+            ],
+            ""bindings"": [
+                {
+                    ""name"": """",
+                    ""id"": ""60796e64-c22e-4f41-a52f-70063f0ae8e8"",
+                    ""path"": ""<Keyboard>/1"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""SelectTower1"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""b7358045-8672-4228-8757-e35101803d07"",
+                    ""path"": ""<Keyboard>/2"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""SelectTower2"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""61abc1d4-54a9-4ed6-9b0b-12e5b0579395"",
+                    ""path"": ""<Keyboard>/3"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""SelectTower3"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                }
+            ]
         }
     ],
     ""controlSchemes"": []
@@ -196,6 +275,11 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
         m_TowerPlacement_StartPlacement = m_TowerPlacement.FindAction("StartPlacement", throwIfNotFound: true);
         m_TowerPlacement_CancelPlacement = m_TowerPlacement.FindAction("CancelPlacement", throwIfNotFound: true);
         m_TowerPlacement_PlaceTower = m_TowerPlacement.FindAction("PlaceTower", throwIfNotFound: true);
+        // TowerSelection
+        m_TowerSelection = asset.FindActionMap("TowerSelection", throwIfNotFound: true);
+        m_TowerSelection_SelectTower1 = m_TowerSelection.FindAction("SelectTower1", throwIfNotFound: true);
+        m_TowerSelection_SelectTower2 = m_TowerSelection.FindAction("SelectTower2", throwIfNotFound: true);
+        m_TowerSelection_SelectTower3 = m_TowerSelection.FindAction("SelectTower3", throwIfNotFound: true);
     }
 
     public void Dispose()
@@ -361,6 +445,68 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
         }
     }
     public TowerPlacementActions @TowerPlacement => new TowerPlacementActions(this);
+
+    // TowerSelection
+    private readonly InputActionMap m_TowerSelection;
+    private List<ITowerSelectionActions> m_TowerSelectionActionsCallbackInterfaces = new List<ITowerSelectionActions>();
+    private readonly InputAction m_TowerSelection_SelectTower1;
+    private readonly InputAction m_TowerSelection_SelectTower2;
+    private readonly InputAction m_TowerSelection_SelectTower3;
+    public struct TowerSelectionActions
+    {
+        private @PlayerInputs m_Wrapper;
+        public TowerSelectionActions(@PlayerInputs wrapper) { m_Wrapper = wrapper; }
+        public InputAction @SelectTower1 => m_Wrapper.m_TowerSelection_SelectTower1;
+        public InputAction @SelectTower2 => m_Wrapper.m_TowerSelection_SelectTower2;
+        public InputAction @SelectTower3 => m_Wrapper.m_TowerSelection_SelectTower3;
+        public InputActionMap Get() { return m_Wrapper.m_TowerSelection; }
+        public void Enable() { Get().Enable(); }
+        public void Disable() { Get().Disable(); }
+        public bool enabled => Get().enabled;
+        public static implicit operator InputActionMap(TowerSelectionActions set) { return set.Get(); }
+        public void AddCallbacks(ITowerSelectionActions instance)
+        {
+            if (instance == null || m_Wrapper.m_TowerSelectionActionsCallbackInterfaces.Contains(instance)) return;
+            m_Wrapper.m_TowerSelectionActionsCallbackInterfaces.Add(instance);
+            @SelectTower1.started += instance.OnSelectTower1;
+            @SelectTower1.performed += instance.OnSelectTower1;
+            @SelectTower1.canceled += instance.OnSelectTower1;
+            @SelectTower2.started += instance.OnSelectTower2;
+            @SelectTower2.performed += instance.OnSelectTower2;
+            @SelectTower2.canceled += instance.OnSelectTower2;
+            @SelectTower3.started += instance.OnSelectTower3;
+            @SelectTower3.performed += instance.OnSelectTower3;
+            @SelectTower3.canceled += instance.OnSelectTower3;
+        }
+
+        private void UnregisterCallbacks(ITowerSelectionActions instance)
+        {
+            @SelectTower1.started -= instance.OnSelectTower1;
+            @SelectTower1.performed -= instance.OnSelectTower1;
+            @SelectTower1.canceled -= instance.OnSelectTower1;
+            @SelectTower2.started -= instance.OnSelectTower2;
+            @SelectTower2.performed -= instance.OnSelectTower2;
+            @SelectTower2.canceled -= instance.OnSelectTower2;
+            @SelectTower3.started -= instance.OnSelectTower3;
+            @SelectTower3.performed -= instance.OnSelectTower3;
+            @SelectTower3.canceled -= instance.OnSelectTower3;
+        }
+
+        public void RemoveCallbacks(ITowerSelectionActions instance)
+        {
+            if (m_Wrapper.m_TowerSelectionActionsCallbackInterfaces.Remove(instance))
+                UnregisterCallbacks(instance);
+        }
+
+        public void SetCallbacks(ITowerSelectionActions instance)
+        {
+            foreach (var item in m_Wrapper.m_TowerSelectionActionsCallbackInterfaces)
+                UnregisterCallbacks(item);
+            m_Wrapper.m_TowerSelectionActionsCallbackInterfaces.Clear();
+            AddCallbacks(instance);
+        }
+    }
+    public TowerSelectionActions @TowerSelection => new TowerSelectionActions(this);
     public interface IPlayerMovementActions
     {
         void OnMovement(InputAction.CallbackContext context);
@@ -370,5 +516,11 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
         void OnStartPlacement(InputAction.CallbackContext context);
         void OnCancelPlacement(InputAction.CallbackContext context);
         void OnPlaceTower(InputAction.CallbackContext context);
+    }
+    public interface ITowerSelectionActions
+    {
+        void OnSelectTower1(InputAction.CallbackContext context);
+        void OnSelectTower2(InputAction.CallbackContext context);
+        void OnSelectTower3(InputAction.CallbackContext context);
     }
 }

--- a/Assets/playerInputs.inputactions
+++ b/Assets/playerInputs.inputactions
@@ -143,7 +143,18 @@
                     "name": "",
                     "id": "b19cdc51-52b4-4012-9de1-b597b8515c08",
                     "path": "<Keyboard>/#(C)",
-                    "interactions": "",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CancelPlacement",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "47d6e586-d32d-4a4a-9d04-6338849a26ad",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "Press",
                     "processors": "",
                     "groups": "",
                     "action": "CancelPlacement",
@@ -158,6 +169,74 @@
                     "processors": "",
                     "groups": "",
                     "action": "PlaceTower",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "TowerSelection",
+            "id": "247614b0-e918-4fbd-bb5a-0b68b48bbcf7",
+            "actions": [
+                {
+                    "name": "SelectTower1",
+                    "type": "Button",
+                    "id": "bca5ff68-2b58-4914-8f29-c20929386a3f",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "SelectTower2",
+                    "type": "Button",
+                    "id": "8643e968-87f8-4240-b352-3334b84fbd17",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "SelectTower3",
+                    "type": "Button",
+                    "id": "e9a968f5-6ff3-40a7-b405-bdee9475be3a",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "60796e64-c22e-4f41-a52f-70063f0ae8e8",
+                    "path": "<Keyboard>/1",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectTower1",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b7358045-8672-4228-8757-e35101803d07",
+                    "path": "<Keyboard>/2",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectTower2",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "61abc1d4-54a9-4ed6-9b0b-12e5b0579395",
+                    "path": "<Keyboard>/3",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectTower3",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/playerInputs.inputactions
+++ b/Assets/playerInputs.inputactions
@@ -153,7 +153,7 @@
                 {
                     "name": "",
                     "id": "47d6e586-d32d-4a4a-9d04-6338849a26ad",
-                    "path": "<Mouse>/rightButton",
+                    "path": "<Mouse>/middleButton",
                     "interactions": "Press",
                     "processors": "",
                     "groups": "",

--- a/Assets/prefabs/Enemies/Standard.prefab
+++ b/Assets/prefabs/Enemies/Standard.prefab
@@ -740,7 +740,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   health: 10
   maxhealth: 10
-  speed: 5
+  speed: 2
   rotationSpeed: 5
   target: {fileID: 0}
   positionIndex: 0

--- a/Assets/scripts/Towers/CharacterSelection.cs
+++ b/Assets/scripts/Towers/CharacterSelection.cs
@@ -27,6 +27,12 @@ public class CharacterSelectionManager : MonoBehaviour
     private void Awake()
     {
         playerInputs = new PlayerInputs();
+        // Map keyboard shortcuts for selecting towers
+        playerInputs.TowerSelection.SelectTower1.performed += context => SelectTower(0);
+        playerInputs.TowerSelection.SelectTower2.performed += context => SelectTower(1);
+        playerInputs.TowerSelection.SelectTower3.performed += context => SelectTower(2);
+
+        playerInputs.TowerPlacement.CancelPlacement.performed += context => CancelTowerPlacement();
     }
 
     void Start()
@@ -62,6 +68,11 @@ public class CharacterSelectionManager : MonoBehaviour
         {
             Debug.LogError("Invalid tower index selected.");
             return;
+        }
+
+        if (isPlacingTower)
+        {
+            CancelTowerPlacement();
         }
 
         selectedTowerPrefab = towerPrefabs[towerIndex];

--- a/Assets/scripts/Towers/CharacterSelection.cs
+++ b/Assets/scripts/Towers/CharacterSelection.cs
@@ -23,6 +23,8 @@ public class CharacterSelectionManager : MonoBehaviour
 
     // Stores the calculated tower position
     private Vector3 towerPlacementPosition;
+    private int[] towerPlacementLimits = { 4, 2, 1 }; // Maximum placements for each tower
+    private int[] towerPlacementCounts;
 
     private void Awake()
     {
@@ -37,6 +39,7 @@ public class CharacterSelectionManager : MonoBehaviour
 
     void Start()
     {
+        towerPlacementCounts = new int[towerPlacementLimits.Length];
         currencyManager = GameObject.FindGameObjectWithTag("Master").GetComponent<CurrencyManager>();
 
         // Assign listeners for tower selection buttons
@@ -69,6 +72,13 @@ public class CharacterSelectionManager : MonoBehaviour
             Debug.LogError("Invalid tower index selected.");
             return;
         }
+
+        if (towerPlacementCounts[towerIndex] >= towerPlacementLimits[towerIndex])
+        {
+            Debug.Log($"Tower {towerIndex + 1} has reached its placement limit.");
+            return;
+        }
+
 
         if (isPlacingTower)
         {
@@ -221,6 +231,13 @@ public class CharacterSelectionManager : MonoBehaviour
         if (towerBehaviour != null)
         {
             towerBehaviour.enabled = true;
+        }
+
+        int towerIndex = System.Array.IndexOf(towerPrefabs, selectedTowerPrefab);
+        if (towerIndex >= 0)
+        {
+            towerPlacementCounts[towerIndex]++;
+            Debug.Log($"Tower {towerIndex + 1} placed. Total placed: {towerPlacementCounts[towerIndex]}");
         }
 
         currentTower = null;

--- a/Assets/scripts/Towers/CharacterSelection.cs
+++ b/Assets/scripts/Towers/CharacterSelection.cs
@@ -16,7 +16,7 @@ public class CharacterSelectionManager : MonoBehaviour
     private GameObject currentTower;
     private bool isPlacingTower = false;
     private bool cancelPressed = false;
-    private int towerCost = 1;
+    private int[] towerCosts = { 1, 3, 6 };
     private CurrencyManager currencyManager;
 
     private PlayerInputs playerInputs;
@@ -221,9 +221,18 @@ public class CharacterSelectionManager : MonoBehaviour
         Debug.Log($"Tower placed at: {finalPosition}");
         currentTower.tag = "Tower";
 
+        int towerIndex = System.Array.IndexOf(towerPrefabs, selectedTowerPrefab);
+        if (towerIndex < 0 || towerIndex >= towerCosts.Length)
+        {
+            Debug.LogError("Invalid tower index for cost deduction.");
+            return;
+        }
+
+        int towerCost = towerCosts[towerIndex];
+
         if (!currencyManager.SpendCurrency(towerCost))
         {
-            Debug.Log("Not enough currency!");
+            Debug.Log($"Not enough currency! This tower costs {towerCost} currency");
             return;
         }
 
@@ -233,7 +242,6 @@ public class CharacterSelectionManager : MonoBehaviour
             towerBehaviour.enabled = true;
         }
 
-        int towerIndex = System.Array.IndexOf(towerPrefabs, selectedTowerPrefab);
         if (towerIndex >= 0)
         {
             towerPlacementCounts[towerIndex]++;


### PR DESCRIPTION
Added keyboard mapping to the tower buttons, 1,2,3 for the respective tower, and "C" or "middle mouse button" for cancelling tower placement. Also changed the tower targeting logic for "FIRST" instead of "CLOSEST" to make more sense and cleaned up the reload logic of the towers. 